### PR TITLE
reset color on PROMPT_COMMAND

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -30,14 +30,14 @@ git_completion_script=/usr/local/etc/bash_completion.d/git-completion.bash
 test -s $git_completion_script && source $git_completion_script
 
 # A more colorful prompt - Updated to work with el caption
-c_reset="$(tput setaf 2)"
+c_reset='\[\e[0m\]'
 c_path="$(tput setaf 1)"
 c_git_dirty="$(tput setaf 1)"
 c_git_clean="$(tput setaf 2)"
 c_white="$(tput setaf 7)"
 
 # PS1 is the variable for the prompt you see everytime you hit enter
-PROMPT_COMMAND=$PROMPT_COMMAND' PS1="${c_path}\W${c_reset}$(git_prompt) :> "'
+PROMPT_COMMAND=$PROMPT_COMMAND' PS1="${c_path}\W${c_reset}$(git_prompt)${c_reset} :> "'
 
 # export PS1='\n\[\033[0;31m\]\W\033[0m\]$(git_prompt)${c_reset} ] :> '
 export PS1='\n\[\033[0;31m\]\W\[\033[0m\]$(git_prompt)\[\033[0m\]:> '


### PR DESCRIPTION
Thanks for the fix using tput colors. Cool that you figured that out.

Although your solution fixed the escaped-color-codes issue in Terminal, it made my default text color green in any non-git directories in iTerm2. (My default color in iTerm is white, not green). I discovered that this was because the .bash_profile only reset the color to white in the git repository directories (Line 61). So I added a c_reset in line 40 after the git_prompt function call.

I also made the reset color '[\e[0m]' so that it reverts to the user's specific default color, which may not always be white or green. 
